### PR TITLE
Methods Equals and LessThan now Private

### DIFF
--- a/pkg/ams/expression/comparison.go
+++ b/pkg/ams/expression/comparison.go
@@ -38,7 +38,7 @@ func (e Eq) Evaluate(input Input) Expression {
 		return bp
 	}
 	if len(constants) == 2 {
-		return Bool(constants[0].Equals(constants[1]))
+		return Bool(constants[0].equals(constants[1]))
 	}
 	return Eq{Args: nextArgs}
 }
@@ -49,7 +49,7 @@ func (e Ne) Evaluate(input Input) Expression {
 		return bp
 	}
 	if len(constants) == 2 {
-		return Bool(!constants[0].Equals(constants[1]))
+		return Bool(!constants[0].equals(constants[1]))
 	}
 	return Ne{Args: nextArgs}
 }
@@ -60,7 +60,7 @@ func (e Lt) Evaluate(input Input) Expression {
 		return bp
 	}
 	if len(constants) == 2 {
-		return Bool(constants[0].LessThan(constants[1]))
+		return Bool(constants[0].lessThan(constants[1]))
 	}
 	return Lt{Args: nextArgs}
 }
@@ -71,7 +71,7 @@ func (e Le) Evaluate(input Input) Expression {
 		return bp
 	}
 	if len(constants) == 2 {
-		return Bool(!constants[1].LessThan(constants[0]))
+		return Bool(!constants[1].lessThan(constants[0]))
 	}
 	return Le{Args: nextArgs}
 }
@@ -82,7 +82,7 @@ func (e Gt) Evaluate(input Input) Expression {
 		return bp
 	}
 	if len(constants) == 2 {
-		return Bool(constants[1].LessThan(constants[0]))
+		return Bool(constants[1].lessThan(constants[0]))
 	}
 	return Gt{Args: nextArgs}
 }
@@ -93,7 +93,7 @@ func (e Ge) Evaluate(input Input) Expression {
 		return bp
 	}
 	if len(constants) == 2 {
-		return Bool(!constants[0].LessThan(constants[1]))
+		return Bool(!constants[0].lessThan(constants[1]))
 	}
 	return Ge{Args: nextArgs}
 }
@@ -104,7 +104,7 @@ func (e Between) Evaluate(input Input) Expression {
 		return bp
 	}
 	if len(constants) == 3 {
-		return Bool(!constants[0].LessThan(constants[1]) && !constants[2].LessThan(constants[0]))
+		return Bool(!constants[0].lessThan(constants[1]) && !constants[2].lessThan(constants[0]))
 	}
 	return Between{Args: nextArgs}
 }
@@ -115,7 +115,7 @@ func (e NotBetween) Evaluate(input Input) Expression {
 		return bp
 	}
 	if len(constants) == 3 {
-		return Bool(constants[0].LessThan(constants[1]) || constants[2].LessThan(constants[0]))
+		return Bool(constants[0].lessThan(constants[1]) || constants[2].lessThan(constants[0]))
 	}
 	return NotBetween{Args: nextArgs}
 }

--- a/pkg/ams/expression/constants.go
+++ b/pkg/ams/expression/constants.go
@@ -2,8 +2,8 @@ package expression
 
 type Constant interface {
 	Expression
-	Equals(c Constant) bool
-	LessThan(c Constant) bool
+	equals(c Constant) bool
+	lessThan(c Constant) bool
 }
 
 type ArrayConstant interface {
@@ -60,33 +60,33 @@ func ConstantFrom(v any) Constant {
 	return UNSET
 }
 
-func (n Number) Equals(c Constant) bool {
+func (n Number) equals(c Constant) bool {
 	return n == c.(Number) //nolint:forcetypeassert
 }
 
-func (n Number) LessThan(c Constant) bool {
+func (n Number) lessThan(c Constant) bool {
 	return n < c.(Number) //nolint:forcetypeassert
 }
 
-func (s String) Equals(c Constant) bool {
+func (s String) equals(c Constant) bool {
 	return s == c.(String) //nolint:forcetypeassert
 }
 
-func (s String) LessThan(c Constant) bool {
+func (s String) lessThan(c Constant) bool {
 	return s < c.(String) //nolint:forcetypeassert
 }
 
-func (b Bool) Equals(c Constant) bool {
+func (b Bool) equals(c Constant) bool {
 	return b == c.(Bool) //nolint:forcetypeassert
 }
 
-func (b Bool) LessThan(c Constant) bool {
+func (b Bool) lessThan(c Constant) bool {
 	return bool(!b && c.(Bool)) //nolint:forcetypeassert
 }
 
 func (n NumberArray) Contains(c Constant) bool {
 	for _, v := range n {
-		if v.Equals(c) {
+		if v.equals(c) {
 			return true
 		}
 	}
@@ -95,7 +95,7 @@ func (n NumberArray) Contains(c Constant) bool {
 
 func (s StringArray) Contains(c Constant) bool {
 	for _, v := range s {
-		if v.Equals(c) {
+		if v.equals(c) {
 			return true
 		}
 	}
@@ -104,7 +104,7 @@ func (s StringArray) Contains(c Constant) bool {
 
 func (b BoolArray) Contains(c Constant) bool {
 	for _, v := range b {
-		if v.Equals(c) {
+		if v.equals(c) {
 			return true
 		}
 	}
@@ -171,26 +171,26 @@ func (b Bool) Evaluate(input Input) Expression {
 	return b
 }
 
-func (s StringArray) Equals(c Constant) bool {
+func (s StringArray) equals(c Constant) bool {
 	return false
 }
 
-func (s StringArray) LessThan(c Constant) bool {
+func (s StringArray) lessThan(c Constant) bool {
 	return false
 }
 
-func (b BoolArray) Equals(c Constant) bool {
+func (b BoolArray) equals(c Constant) bool {
 	return false
 }
 
-func (b BoolArray) LessThan(c Constant) bool {
+func (b BoolArray) lessThan(c Constant) bool {
 	return false
 }
 
-func (n NumberArray) Equals(c Constant) bool {
+func (n NumberArray) equals(c Constant) bool {
 	return false
 }
 
-func (n NumberArray) LessThan(c Constant) bool {
+func (n NumberArray) lessThan(c Constant) bool {
 	return false
 }

--- a/pkg/ams/expression/constants_test.go
+++ b/pkg/ams/expression/constants_test.go
@@ -18,8 +18,8 @@ func TestDCNNumber_Equals(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.n.Equals(tt.c); got != tt.expected {
-				t.Errorf("DCNNumber.Equals() = %v, expected %v", got, tt.expected)
+			if got := tt.n.equals(tt.c); got != tt.expected {
+				t.Errorf("DCNNumber.equals() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -38,8 +38,8 @@ func TestDCNNumber_LessThan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.n.LessThan(tt.c); got != tt.expected {
-				t.Errorf("DCNNumber.LessThan() = %v, expected %v", got, tt.expected)
+			if got := tt.n.lessThan(tt.c); got != tt.expected {
+				t.Errorf("DCNNumber.lessThan() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -58,8 +58,8 @@ func TestDCNString_Equals(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.s.Equals(tt.c); got != tt.expected {
-				t.Errorf("DCNString.Equals() = %v, expected %v", got, tt.expected)
+			if got := tt.s.equals(tt.c); got != tt.expected {
+				t.Errorf("DCNString.equals() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -78,8 +78,8 @@ func TestDCNString_LessThan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.s.LessThan(tt.c); got != tt.expected {
-				t.Errorf("DCNString.LessThan() = %v, expected %v", got, tt.expected)
+			if got := tt.s.lessThan(tt.c); got != tt.expected {
+				t.Errorf("DCNString.lessThan() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -98,8 +98,8 @@ func TestDCNBool_Equals(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.b.Equals(tt.c); got != tt.expected {
-				t.Errorf("DCNBool.Equals() = %v, expected %v", got, tt.expected)
+			if got := tt.b.equals(tt.c); got != tt.expected {
+				t.Errorf("DCNBool.equals() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -118,8 +118,8 @@ func TestDCNBool_LessThan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.b.LessThan(tt.c); got != tt.expected {
-				t.Errorf("DCNBool.LessThan() = %v, expected %v", got, tt.expected)
+			if got := tt.b.lessThan(tt.c); got != tt.expected {
+				t.Errorf("DCNBool.lessThan() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -143,11 +143,11 @@ func TestDCNArrayConstant_Equals(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.arr.Equals(tt.c); got != tt.expected {
-				t.Errorf("DCNArrayConstant.Equals() = %v, expected %v", got, tt.expected)
+			if got := tt.arr.equals(tt.c); got != tt.expected {
+				t.Errorf("DCNArrayConstant.equals() = %v, expected %v", got, tt.expected)
 			}
-			if got := tt.arr.LessThan(tt.arr); got != tt.expected {
-				t.Errorf("DCNArrayConstant.LessThan() = %v, expected %v", got, tt.expected)
+			if got := tt.arr.lessThan(tt.arr); got != tt.expected {
+				t.Errorf("DCNArrayConstant.lessThan() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}

--- a/pkg/ams/expression/wildcard.go
+++ b/pkg/ams/expression/wildcard.go
@@ -12,10 +12,10 @@ func (b Wildcard) Evaluate(input Input) Expression {
 	return b
 }
 
-func (b Wildcard) Equals(Constant) bool {
+func (b Wildcard) equals(Constant) bool {
 	return false
 }
 
-func (b Wildcard) LessThan(Constant) bool {
+func (b Wildcard) lessThan(Constant) bool {
 	return false
 }


### PR DESCRIPTION
The methods `Equals` and `LessThan` of the `Constant` interface are not intended to be implemented by types other than the ones defined in the `expression` package. Therefore this PR changes the methods to private.